### PR TITLE
Show domain deprecated error handling

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,9 +5,12 @@ const options = {
   filename: 'fixtures/UiAutocompleteMinimal.vue'
 }
 
-vuedoc.parse(options)
+const errorBoundary = require('domain').create();
+
+errorBoundary.on('error', (err) => {
+  console.error('got an error');
+  console.error(err);
+}).run(() => {
+  vuedoc.parse(options)
   .then((component) => console.log(component))
-  .catch((err) => {
-    console.error('got an error')
-    console.error(err)
-  })
+});


### PR DESCRIPTION
This is the only thing that'll work for your use case unfortunately but it is not very reliable.

I would recommend switching to a better origin library.